### PR TITLE
サプライチェーン攻撃対策に、Dependabot の cooldown を設定（７日）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       day: monday
       time: '09:00'
       timezone: Asia/Tokyo
+    cooldown:
+      default-days: 7
     groups:
       nadesiko:
         patterns:


### PR DESCRIPTION
サプライチェーン攻撃の影響を緩和するために、cooldown を７日に設定する。